### PR TITLE
Ajouter le support de pagy 9

### DIFF
--- a/lib/api-pagination.rb
+++ b/lib/api-pagination.rb
@@ -50,14 +50,14 @@ module ApiPagination
       if Pagy::DEFAULT[:max_per_page] && options[:per_page] > Pagy::DEFAULT[:max_per_page]
         options[:per_page] = Pagy::DEFAULT[:max_per_page]
       elsif options[:per_page] <= 0
-        options[:per_page] = Pagy::DEFAULT[:items]
+        options[:per_page] = Pagy::DEFAULT[:limit]
       end
 
       pagy = pagy_from(collection, options)
       collection = if collection.respond_to?(:offset) && collection.respond_to?(:limit)
-        collection.offset(pagy.offset).limit(pagy.items)
+        collection.offset(pagy.offset).limit(pagy.limit)
       else
-        collection[pagy.offset, pagy.items]
+        collection[pagy.offset, pagy.limit]
       end
 
       return [collection, pagy]
@@ -70,7 +70,7 @@ module ApiPagination
         count = collection.is_a?(Array) ? collection.count : collection.count(:all)
       end
 
-      Pagy.new(count: count, items: options[:per_page], page: options[:page])
+      Pagy.new(count: count, limit: options[:per_page], page: options[:page])
     end
 
     def pagy_pages_from(pagy)

--- a/spec/rails_spec.rb
+++ b/spec/rails_spec.rb
@@ -286,7 +286,7 @@ describe NumbersController, :type => :controller do
 
           expect(response.header['Per-Page']).to eq(
             case ApiPagination.config.paginator
-            when :pagy          then Pagy::DEFAULT[:items].to_s
+            when :pagy          then Pagy::DEFAULT[:limit].to_s
             when :kaminari      then Kaminari.config.default_per_page.to_s
             when :will_paginate then WillPaginate.per_page.to_s
             end
@@ -301,7 +301,7 @@ describe NumbersController, :type => :controller do
 
         expect(response.header['Per-Page']).to eq(
           case ApiPagination.config.paginator
-          when :pagy          then Pagy::DEFAULT[:items].to_s
+          when :pagy          then Pagy::DEFAULT[:limit].to_s
           when :kaminari      then Kaminari.config.default_per_page.to_s
           when :will_paginate then WillPaginate.per_page.to_s
           end


### PR DESCRIPTION
Pagy 9 a quelques breaking changes, principalement sur le nom des attributs "pages", qui deviennent "limit".